### PR TITLE
Target for net47 + removed dependency on external Http package

### DIFF
--- a/WebPush.Test/ECKeyHelperTest.cs
+++ b/WebPush.Test/ECKeyHelperTest.cs
@@ -25,8 +25,6 @@ namespace WebPush.Test
 
             Assert.Equal(65, publicKeyLength);
             Assert.Equal(32, privateKeyLength);
-
-            ;
         }
 
         [Fact]

--- a/WebPush.nuspec
+++ b/WebPush.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>WebPush</id>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <authors>Cory Thompson</authors>
     <owners>Cory Thompson</owners>
     <licenseUrl>https://github.com/coryjthompson/web-push-csharp/blob/master/LICENSE</licenseUrl>
@@ -14,27 +14,31 @@
     <dependencies>	
         <group targetFramework="netcoreapp1.0">
             <dependency id="BouncyCastle.NetCore" version="1.8.1.3"/>
-            <dependency id="Newtonsoft.Json" version="10.0.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
         </group>
         <group targetFramework="netcoreapp1.1">
             <dependency id="BouncyCastle.NetCore" version="1.8.1.3"/>
-            <dependency id="Newtonsoft.Json" version="10.0.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
         </group>
         <group targetFramework="netstandard1.3">
             <dependency id="BouncyCastle.NetCore" version="1.8.1.3"/>
-            <dependency id="Newtonsoft.Json" version="10.0.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
+            <dependency id="System.Net.Http" version="4.3.3"/>
         </group>
 
         <group targetFramework="net45">
             <dependency id="BouncyCastle" version="1.8.1"/>
-	    <dependency id="Microsoft.Net.Http" version="2.2.29" />
-            <dependency id="Newtonsoft.Json" version="10.0.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
         </group>
 
         <group targetFramework="net46">
             <dependency id="BouncyCastle" version="1.8.1"/>
-            <dependency id="Microsoft.Net.Http" version="2.2.29" />
-            <dependency id="Newtonsoft.Json" version="10.0.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
+        </group>
+
+        <group targetFramework="net47">
+            <dependency id="BouncyCastle" version="1.8.1"/>
+            <dependency id="Newtonsoft.Json" version="10.0.3"/>
         </group>
     </dependencies>
   </metadata>

--- a/WebPush.sln
+++ b/WebPush.sln
@@ -1,10 +1,17 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.6
+VisualStudioVersion = 15.0.26730.16
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebPush", "WebPush\WebPush.csproj", "{4CDE5EA4-CEF7-4CA0-B1C7-512D1D355E00}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebPush.Test", "WebPush.Test\WebPush.Test.csproj", "{61890D98-5101-4F64-B4B1-E00351A42133}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{00145B67-A35F-46B3-B69B-45ABEB45905A}"
+	ProjectSection(SolutionItems) = preProject
+		build.cmd = build.cmd
+		README.md = README.md
+		WebPush.nuspec = WebPush.nuspec
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -43,5 +50,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {331EB5B3-39C1-44A0-B1D4-AF44344075D9}
 	EndGlobalSection
 EndGlobal

--- a/WebPush/WebPush.csproj
+++ b/WebPush/WebPush.csproj
@@ -1,15 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netstandard1.3;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netstandard1.3;net45;net46;net47</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46'">
-    <PackageReference Include="BouncyCastle" Version="1.8.1" /> 
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+  <ItemGroup Condition="'$(TargetFramework)'=='net45' OR '$(TargetFramework)'=='net46' OR '$(TargetFramework)'=='net47'">
+    <PackageReference Include="BouncyCastle" Version="1.8.1" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp1.0' OR '$(TargetFramework)'=='netcoreapp1.1' OR '$(TargetFramework)'=='netstandard1.3'">
     <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" /> 
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+    <PackageReference Include="BouncyCastle.NetCore" Version="1.8.1.3" />
+    <PackageReference Include="System.Net.Http" version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WebPush/WebPushClient.cs
+++ b/WebPush/WebPushClient.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using WebPush.Util;
+
+[assembly: InternalsVisibleTo("WebPush.Test")]
 
 namespace WebPush
 {


### PR DESCRIPTION
Hi @coryjthompson,

Great package, I'm looking forward to using it!

I had to use it in a .NET 4.7 library and noticed that `System.Net.Http` is available there natively. So I removed the package reference to `Microsoft.Net.Http` from the .NET Framework 4.5, 4.6 and 4.7 configurations (added 4.7).

I updated Newtonsoft Json and added an `InternalsVisible` Attribute since your changing of the access modifiers of the utils broke the tests. 

I also raised the version so my nuget would pick it up as an update.

[Related StackOverflow Question](https://stackoverflow.com/questions/46790546/system-net-http-in-net47)