### PR TITLE
make HandleResponse public

### DIFF
--- a/WebPush/WebPushClient.cs
+++ b/WebPush/WebPushClient.cs
@@ -346,7 +346,7 @@ namespace WebPush
         /// </summary>
         /// <param name="response"></param>
         /// <param name="subscription"></param>
-        private static void HandleResponse(HttpResponseMessage response, PushSubscription subscription)
+        public static void HandleResponse(HttpResponseMessage response, PushSubscription subscription)
         {
             // Successful
             if (response.StatusCode == HttpStatusCode.Created)


### PR DESCRIPTION
Make HandleResponse public so that users passing in custom headers (like TTL) can still call this function to get the same WebPushException the rest of the code expects instead of having to copy this function into their code as well.